### PR TITLE
Decorator pattern with `by delegate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,15 +129,14 @@ As we said above, expiration is critical in caching framework because it prevent
 
 ```kotlin
 class ExpirableCache(private val delegate: Cache,
-                     private val flushInterval: Long = TimeUnit.MINUTES.toMillis(1)) : Cache {
+                     private val flushInterval: Long = TimeUnit.MINUTES.toMillis(1)) : Cache by delegate {
 	private var lastFlushTime = System.nanoTime()
 
 	override val size: Int
-		get() = delegate.size
-
-	override fun set(key: Any, value: Any) {
-		delegate[key] = value
-	}
+		get() {
+			recycle()
+			return delegate.size
+		}
 
 	override fun remove(key: Any): Any? {
 		recycle()
@@ -148,8 +147,6 @@ class ExpirableCache(private val delegate: Cache,
 		recycle()
 		return delegate[key]
 	}
-
-	override fun clear() = delegate.clear()
 
 	private fun recycle() {
 		val shouldRecycle = System.nanoTime() - lastFlushTime >= TimeUnit.MILLISECONDS.toNanos(flushInterval)

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ By now our cache will keep all the entries until we remove them manually, it can
 Since we already have `PerpetualCache` and we want to **add responsibilities** to this class, the **[Decorator Pattern](https://en.wikipedia.org/wiki/Decorator_pattern)** is the best choice here.
 
 ```kotlin
-class LRUCache(private val delegate: Cache, private val minimalSize: Int = DEFAULT_SIZE) : Cache {
+class LRUCache(private val delegate: Cache, private val minimalSize: Int = DEFAULT_SIZE) : Cache by delegate {
 	private val keyMap = object : LinkedHashMap<Any, Any>(minimalSize, .75f, true) {
 		override fun removeEldestEntry(eldest: MutableMap.MutableEntry<Any, Any>): Boolean {
 			val tooManyCachedItems = size > minimalSize
@@ -93,15 +93,10 @@ class LRUCache(private val delegate: Cache, private val minimalSize: Int = DEFAU
 
 	private var eldestKeyToRemove: Any? = null
 
-	override val size: Int
-		get() = delegate.size
-
 	override fun set(key: Any, value: Any) {
 		delegate[key] = value
 		cycleKeyMap(key)
 	}
-
-	override fun remove(key: Any) = delegate.remove(key)
 
 	override fun get(key: Any): Any? {
 		keyMap[key]

--- a/src/main/kotlin/io/github/kezhenxu94/cache/lite/impl/ExpirableCache.kt
+++ b/src/main/kotlin/io/github/kezhenxu94/cache/lite/impl/ExpirableCache.kt
@@ -9,7 +9,7 @@ import java.util.concurrent.TimeUnit
  * @author kezhenxu94 (kezhenxu94 at 163 dot com)
  */
 class ExpirableCache(private val delegate: Cache,
-                     private val flushInterval: Long = TimeUnit.MINUTES.toMillis(1)) : Cache {
+                     private val flushInterval: Long = TimeUnit.MINUTES.toMillis(1)) : Cache by delegate {
 	private var lastFlushTime = System.nanoTime()
 
 	override val size: Int
@@ -17,10 +17,6 @@ class ExpirableCache(private val delegate: Cache,
 			recycle()
 			return delegate.size
 		}
-
-	override fun set(key: Any, value: Any) {
-		delegate[key] = value
-	}
 
 	override fun remove(key: Any): Any? {
 		recycle()
@@ -31,8 +27,6 @@ class ExpirableCache(private val delegate: Cache,
 		recycle()
 		return delegate[key]
 	}
-
-	override fun clear() = delegate.clear()
 
 	private fun recycle() {
 		val shouldRecycle = System.nanoTime() - lastFlushTime >= TimeUnit.MILLISECONDS.toNanos(flushInterval)

--- a/src/main/kotlin/io/github/kezhenxu94/cache/lite/impl/FIFOCache.kt
+++ b/src/main/kotlin/io/github/kezhenxu94/cache/lite/impl/FIFOCache.kt
@@ -8,7 +8,7 @@ import java.util.*
  *
  * @author kezhenxu94 (kezhenxu94 at 163 dot com)
  */
-class FIFOCache(private val delegate: Cache, private val minimalSize: Int = DEFAULT_SIZE) : Cache {
+class FIFOCache(private val delegate: Cache, private val minimalSize: Int = DEFAULT_SIZE) : Cache by delegate {
 	private val keyMap = object : LinkedHashMap<Any, Any>(minimalSize, .75f) {
 		override fun removeEldestEntry(eldest: MutableMap.MutableEntry<Any, Any>): Boolean {
 			val tooManyCachedItems = size > minimalSize
@@ -19,15 +19,10 @@ class FIFOCache(private val delegate: Cache, private val minimalSize: Int = DEFA
 
 	private var eldestKeyToRemove: Any? = null
 
-	override val size: Int
-		get() = delegate.size
-
 	override fun set(key: Any, value: Any) {
 		delegate[key] = value
 		cycleKeyMap(key)
 	}
-
-	override fun remove(key: Any) = delegate.remove(key)
 
 	override fun get(key: Any): Any? {
 		keyMap[key]

--- a/src/main/kotlin/io/github/kezhenxu94/cache/lite/impl/LRUCache.kt
+++ b/src/main/kotlin/io/github/kezhenxu94/cache/lite/impl/LRUCache.kt
@@ -8,7 +8,7 @@ import java.util.*
  *
  * @author kezhenxu94 (kezhenxu94 at 163 dot com)
  */
-class LRUCache(private val delegate: Cache, private val minimalSize: Int = DEFAULT_SIZE) : Cache {
+class LRUCache(private val delegate: Cache, private val minimalSize: Int = DEFAULT_SIZE) : Cache by delegate {
 	private val keyMap = object : LinkedHashMap<Any, Any>(minimalSize, .75f, true) {
 		override fun removeEldestEntry(eldest: MutableMap.MutableEntry<Any, Any>): Boolean {
 			val tooManyCachedItems = size > minimalSize
@@ -19,15 +19,10 @@ class LRUCache(private val delegate: Cache, private val minimalSize: Int = DEFAU
 
 	private var eldestKeyToRemove: Any? = null
 
-	override val size: Int
-		get() = delegate.size
-
 	override fun set(key: Any, value: Any) {
 		delegate[key] = value
 		cycleKeyMap(key)
 	}
-
-	override fun remove(key: Any) = delegate.remove(key)
 
 	override fun get(key: Any): Any? {
 		keyMap[key]

--- a/src/main/kotlin/io/github/kezhenxu94/cache/lite/impl/SoftCache.kt
+++ b/src/main/kotlin/io/github/kezhenxu94/cache/lite/impl/SoftCache.kt
@@ -10,16 +10,13 @@ import java.lang.ref.SoftReference
  *
  * @author kezhenxu94 (kezhenxu94 at 163 dot com)
  */
-class SoftCache(private val delegate: Cache) : Cache {
+class SoftCache(private val delegate: Cache) : Cache by delegate {
 	private val referenceQueue = ReferenceQueue<Any>()
 
 	private class SoftEntry internal constructor(
 			internal val key: Any,
 			value: Any,
 			referenceQueue: ReferenceQueue<Any>) : SoftReference<Any>(value, referenceQueue)
-
-	override val size: Int
-		get() = delegate.size
 
 	override fun set(key: Any, value: Any) {
 		removeUnreachableItems()
@@ -38,8 +35,6 @@ class SoftCache(private val delegate: Cache) : Cache {
 		delegate.remove(key)
 		return null
 	}
-
-	override fun clear() = delegate.clear()
 
 	private fun removeUnreachableItems() {
 		var softEntry = referenceQueue.poll() as SoftEntry?

--- a/src/main/kotlin/io/github/kezhenxu94/cache/lite/impl/WeakCache.kt
+++ b/src/main/kotlin/io/github/kezhenxu94/cache/lite/impl/WeakCache.kt
@@ -10,16 +10,13 @@ import java.lang.ref.WeakReference
  *
  * @author kezhenxu94 (kezhenxu94 at 163 dot com)
  */
-class WeakCache(private val delegate: Cache) : Cache {
+class WeakCache(private val delegate: Cache) : Cache by delegate {
 	private val referenceQueue = ReferenceQueue<Any>()
 
 	private class WeakEntry internal constructor(
 			internal val key: Any,
 			value: Any,
 			referenceQueue: ReferenceQueue<Any>) : WeakReference<Any>(value, referenceQueue)
-
-	override val size: Int
-		get() = delegate.size
 
 	override fun set(key: Any, value: Any) {
 		removeUnreachableItems()
@@ -38,8 +35,6 @@ class WeakCache(private val delegate: Cache) : Cache {
 		delegate.remove(key)
 		return null
 	}
-
-	override fun clear() = delegate.clear()
 
 	private fun removeUnreachableItems() {
 		var weakEntry = referenceQueue.poll() as WeakEntry?


### PR DESCRIPTION
You could use the `Cache by delegate` pattern to decorate your implementations. 

This way you do not have to override all methods manually, as they will be implemented via the delegate.

See https://kotlinlang.org/docs/reference/delegation.html#implementation-by-delegation
