### PR TITLE
Reset lastFlushedTime to avoid permanent expired state

### DIFF
--- a/src/main/kotlin/io/github/kezhenxu94/cache/lite/impl/ExpirableCache.kt
+++ b/src/main/kotlin/io/github/kezhenxu94/cache/lite/impl/ExpirableCache.kt
@@ -30,7 +30,9 @@ class ExpirableCache(private val delegate: Cache,
 
 	private fun recycle() {
 		val shouldRecycle = System.nanoTime() - lastFlushTime >= TimeUnit.MILLISECONDS.toNanos(flushInterval)
-		if (!shouldRecycle) return
-		delegate.clear()
+		if (shouldRecycle) {
+			delegate.clear()
+			lastFlushTime = System.nanoTime()
+		}
 	}
 }

--- a/src/test/kotlin/io/github/kezhenxu94/cache/lite/impl/ExpirableCacheTest.kt
+++ b/src/test/kotlin/io/github/kezhenxu94/cache/lite/impl/ExpirableCacheTest.kt
@@ -20,4 +20,14 @@ class ExpirableCacheTest : BaseCacheTest() {
 		Thread.sleep(TimeUnit.SECONDS.toMillis(5))
 		Assert.assertEquals(0, cache.size)
 	}
+
+    @Test
+    fun shouldExpireMultipleTimes() {
+        Thread.sleep(TimeUnit.SECONDS.toMillis(5))
+        Assert.assertEquals(0, cache.size)
+        cache[1] = 1
+        Assert.assertEquals(1, cache.size)
+        Thread.sleep(TimeUnit.SECONDS.toMillis(5))
+        Assert.assertEquals(0, cache.size)
+    }
 }


### PR DESCRIPTION
This fixes the issue where ExpirableCache is always expired after the initial expiry.
I added a test to verify this new behavior. Feel free to give feedback I'll happily improve this PR. 